### PR TITLE
Refactoring

### DIFF
--- a/include/billiard.hpp
+++ b/include/billiard.hpp
@@ -18,8 +18,7 @@ public:
 	void runSimulation();
 
 private:
-	bool willCollide(const double yl);
-	void calcTrajectory(const double coeff, const double alpha, const double yl);
+	void calcTrajectory(const double alpha);
 
 	double m_r1{};
 	double m_r2{};

--- a/src/billiard.cpp
+++ b/src/billiard.cpp
@@ -12,49 +12,38 @@ Billiard::Billiard(double r1, double r2, double l) //
 void Billiard::runSimulation()
 {
 	const double alpha{std::atan((m_r2 - m_r1) / m_l)};
+	calcTrajectory(alpha);
+}
 
+void Billiard::calcTrajectory(const double alpha)
+{
 	double coeff{std::tan(m_particle.theta)};
 	double yl{coeff * (m_l - m_particle.x) + m_particle.y};
 
-	while (willCollide(yl))
+	while (std::abs(yl) > m_r2)
 	{
 		if (std::abs(m_particle.theta) >= M_PI + alpha)
 		{
 			// end loop if the particle is going to move backwards
-			break;
+			return;
 		}
 
-		calcTrajectory(coeff, alpha, yl);
+		// True if the the collision happens with the upper wall, false with the lower wall
+		const double xi{(yl > m_r2) ? (coeff * m_particle.x + m_r1 - m_particle.y) / (coeff + ((m_r1 - m_r2) / m_l))
+									: (coeff * m_particle.x - m_r1 - m_particle.y) / (coeff + ((m_r2 - m_r1) / m_l))};
+
+		const double theta{(yl > m_r2) ? 2. * alpha - m_particle.theta //
+									   : -2. * alpha - m_particle.theta};
+
+		const double yi{coeff * (xi - m_particle.x) + m_particle.y};
+
+		m_particle = {xi, yi, theta};
 
 		coeff = std::tan(m_particle.theta);
 		yl = coeff * (m_l - m_particle.x) + m_particle.y;
 	}
-}
 
-bool Billiard::willCollide(const double yl)
-{
-	if (std::abs(yl) < m_r2)
-	{
-		// Set the final coords
-		m_particle.x = m_l;
-		m_particle.y = yl;
-
-		return false;
-	}
-
-	return true;
-}
-
-void Billiard::calcTrajectory(const double coeff, const double alpha, const double yl)
-{
-	// True if the the collision happens with the upper wall, false with the lower wall
-	const double xi{(yl > m_r2) ? (coeff * m_particle.x + m_r1 - m_particle.y) / (coeff + ((m_r1 - m_r2) / m_l))
-								: (coeff * m_particle.x - m_r1 - m_particle.y) / (coeff + ((m_r2 - m_r1) / m_l))};
-
-	const double theta{(yl > m_r2) ? 2. * alpha - m_particle.theta //
-								   : -2. * alpha - m_particle.theta};
-
-	const double yi{coeff * (xi - m_particle.x) + m_particle.y};
-
-	m_particle = {xi, yi, theta};
+	// Set the final coords
+	m_particle.x = m_l;
+	m_particle.y = yl;
 }

--- a/tests/billiard.test.cpp
+++ b/tests/billiard.test.cpp
@@ -5,9 +5,10 @@
 
 bool approx_eq(const Particle& particle1, const Particle& particle2)
 {
-	return (particle1.x == doctest::Approx(particle2.x).epsilon(0.0001) && //
-			particle1.y == doctest::Approx(particle2.y).epsilon(0.0001) && //
-			particle1.theta == doctest::Approx(particle2.theta).epsilon(0.0001));
+	const double epsilon{0.0001};
+	return (particle1.x == doctest::Approx(particle2.x).epsilon(epsilon) && //
+			particle1.y == doctest::Approx(particle2.y).epsilon(epsilon) && //
+			particle1.theta == doctest::Approx(particle2.theta).epsilon(epsilon));
 }
 
 TEST_CASE("Testing the Billiard constructor")


### PR DESCRIPTION
This PR removes the function `willCollide`, and moves all the trajectory and collision calculations in the function `calcTrajectory`. By doing that, the function `runSimulation` only calculates $\alpha$ and calls `calcTrajectory`, but this will make it easier to add multiple particles, as we can make the `runSimulation` function handle all the particles and calling `calcTrajectory` for each particle.