### PR TITLE
Add partially inelastic collisions

### DIFF
--- a/equations.md
+++ b/equations.md
@@ -15,12 +15,19 @@ therefore, after a collision we have:
 $$y_{i+1} = \tan\theta_i\ (x_{i+1}-x_i) + y_i $$
 
 ## Generic Billiard
-1. Particle's angle after a collision:
+1. Particle's angle after a collision with elastic collisions:
 Upper wall:
 $$\theta_{i+1} = -\theta_i + 2\alpha$$
 Lower wall:
 $$\theta_{i+1} = -\theta_i - 2\alpha$$
 where $\alpha$ is the angle of the edge, that varies for each shape of the billiard, and all angles are referred to the $x$ axis.
+
+2. Particle's angle after a collision with partially inelastic collisions:  
+Upper wall:
+$$\theta_{i+1} = \alpha - \frac{\pi}{2}+\arctan(\frac{1}{e} \cot(\theta_i-\alpha))$$
+Lower wall:
+$$\theta_{i+1} = -\alpha + \frac{\pi}{2}+\arctan(\frac{1}{e} \cot(\theta_i+\alpha))$$
+where $e$ is the restitution coefficient, $\alpha$ is the angle of the edge, that varies for each shape of the billiard, and all angles are referred to the $x$ axis.
 
 ## Straight line billiard
 1. Equation of the upper wall:

--- a/equations.md
+++ b/equations.md
@@ -27,7 +27,7 @@ Upper wall:
 $$\theta_{i+1} = \alpha - \frac{\pi}{2}+\arctan(\frac{1}{e} \tan(\frac{\pi}{2}-\theta_i+\alpha))$$
 Lower wall:
 $$\theta_{i+1} = -\alpha + \frac{\pi}{2}+\arctan(\frac{1}{e} \tan(\frac{\pi}{2}-\theta_i-\alpha))$$
-where $e$ is the restitution coefficient, $\alpha$ is the angle of the edge, that varies for each shape of the billiard, and all angles are referred to the $x$ axis.
+where $e$ is the coefficient of restitution, $\alpha$ is the angle of the edge, that varies for each shape of the billiard, and all angles are referred to the $x$ axis.
 
 ## Straight line billiard
 1. Equation of the upper wall:

--- a/equations.md
+++ b/equations.md
@@ -24,9 +24,9 @@ where $\alpha$ is the angle of the edge, that varies for each shape of the billi
 
 2. Particle's angle after a collision with partially inelastic collisions:  
 Upper wall:
-$$\theta_{i+1} = \alpha - \frac{\pi}{2}+\arctan(\frac{1}{e} \cot(\theta_i-\alpha))$$
+$$\theta_{i+1} = \alpha - \frac{\pi}{2}+\arctan(\frac{1}{e} \tan(\frac{\pi}{2}-\theta_i+\alpha))$$
 Lower wall:
-$$\theta_{i+1} = -\alpha + \frac{\pi}{2}+\arctan(\frac{1}{e} \cot(\theta_i+\alpha))$$
+$$\theta_{i+1} = -\alpha + \frac{\pi}{2}+\arctan(\frac{1}{e} \tan(\frac{\pi}{2}-\theta_i-\alpha))$$
 where $e$ is the restitution coefficient, $\alpha$ is the angle of the edge, that varies for each shape of the billiard, and all angles are referred to the $x$ axis.
 
 ## Straight line billiard

--- a/include/billiard.hpp
+++ b/include/billiard.hpp
@@ -47,7 +47,7 @@ private:
 	Particle calcParabolicTrajectory(Particle particle, double k) const;
 	Particle calcCircularTrajectory(Particle particle, double R) const;
 
-	double updateAngle(double theta, double alpha) const;
+	double updateAngle(double theta, double alpha, bool isUpperWall) const;
 
 	double m_r1{5.};
 	double m_r2{3.};

--- a/include/billiard.hpp
+++ b/include/billiard.hpp
@@ -19,7 +19,7 @@ class Billiard
 {
 public:
 	Billiard() = default;
-	Billiard(double r1, double r2, double l, BilliardType type = BilliardType::Linear);
+	Billiard(double r1, double r2, double l, BilliardType type = BilliardType::Linear, double e = 1.);
 
 	double getR1() const { return m_r1; }
 	double getL() const { return m_l; }
@@ -54,6 +54,8 @@ private:
 	double m_l{13.};
 
 	BilliardType m_type{BilliardType::Linear};
+
+	double m_e{1.};
 
 	std::vector<Particle> m_particles{};
 };

--- a/include/billiard.hpp
+++ b/include/billiard.hpp
@@ -43,9 +43,11 @@ public:
 	void runSimulation();
 
 private:
-	Particle calcLinearTrajectory(Particle particle, double alpha);
-	Particle calcParabolicTrajectory(Particle particle, double k);
-	Particle calcCircularTrajectory(Particle particle, double R);
+	Particle calcLinearTrajectory(Particle particle, double alpha) const;
+	Particle calcParabolicTrajectory(Particle particle, double k) const;
+	Particle calcCircularTrajectory(Particle particle, double R) const;
+
+	double updateAngle(double theta, double alpha) const;
 
 	double m_r1{5.};
 	double m_r2{3.};

--- a/src/billiard.cpp
+++ b/src/billiard.cpp
@@ -97,15 +97,14 @@ void Billiard::runSimulation()
 	}
 }
 
-Particle Billiard::calcLinearTrajectory(Particle particle, double alpha)
+Particle Billiard::calcLinearTrajectory(Particle particle, double alpha) const
 {
 	double m{std::tan(particle.theta)};
 	double yl{m * (m_l - particle.x) + particle.y};
 
 	while (std::abs(yl) > m_r2)
 	{
-		const double theta{(yl > m_r2) ? 2. * alpha - particle.theta //
-									   : -2. * alpha - particle.theta};
+		const double theta{(yl > m_r2) ? updateAngle(particle.theta, alpha) : updateAngle(particle.theta, -alpha)};
 
 		if (std::abs(theta) > M_PI_2)
 		{
@@ -132,7 +131,7 @@ Particle Billiard::calcLinearTrajectory(Particle particle, double alpha)
 	return particle;
 }
 
-Particle Billiard::calcParabolicTrajectory(Particle particle, double k)
+Particle Billiard::calcParabolicTrajectory(Particle particle, double k) const
 {
 	double m{std::tan(particle.theta)};
 	double yl{m * (m_l - particle.x) + particle.y};
@@ -146,8 +145,7 @@ Particle Billiard::calcParabolicTrajectory(Particle particle, double k)
 		const double xi{numerator * m_l / k};
 
 		const double alpha{std::atan(k * (xi - m_l) / m_l)};
-		const double theta{(yl > m_r2) ? 2. * alpha - particle.theta //
-									   : -2. * alpha - particle.theta};
+		const double theta{(yl > m_r2) ? updateAngle(particle.theta, alpha) : updateAngle(particle.theta, -alpha)};
 
 		if (std::abs(theta) > M_PI_2)
 		{
@@ -170,7 +168,7 @@ Particle Billiard::calcParabolicTrajectory(Particle particle, double k)
 	return particle;
 }
 
-Particle Billiard::calcCircularTrajectory(Particle particle, double R)
+Particle Billiard::calcCircularTrajectory(Particle particle, double R) const
 {
 	double m{std::tan(particle.theta)};
 	double yl{m * (m_l - particle.x) + particle.y};
@@ -187,8 +185,7 @@ Particle Billiard::calcCircularTrajectory(Particle particle, double R)
 		const double yi{m * (xi - particle.x) + particle.y};
 
 		const double alpha{std::atan((xi - m_l) / (R + m_r2 - yi))};
-		const double theta{(yl > m_r2) ? 2. * alpha - particle.theta //
-									   : -2. * alpha - particle.theta};
+		const double theta{(yl > m_r2) ? updateAngle(particle.theta, alpha) : updateAngle(particle.theta, -alpha)};
 
 		if (std::abs(theta) > M_PI_2)
 		{
@@ -209,3 +206,8 @@ Particle Billiard::calcCircularTrajectory(Particle particle, double R)
 	return particle;
 }
 } // namespace tb
+
+double tb::Billiard::updateAngle(double theta, double alpha) const
+{
+	return 2. * alpha - theta;
+}

--- a/src/billiard.cpp
+++ b/src/billiard.cpp
@@ -104,7 +104,9 @@ Particle Billiard::calcLinearTrajectory(Particle particle, double alpha) const
 
 	while (std::abs(yl) > m_r2)
 	{
-		const double theta{(yl > m_r2) ? updateAngle(particle.theta, alpha) : updateAngle(particle.theta, -alpha)};
+		const bool isUpperWall{yl > m_r2};
+
+		const double theta{updateAngle(particle.theta, alpha, isUpperWall)};
 
 		if (std::abs(theta) > M_PI_2)
 		{
@@ -113,7 +115,7 @@ Particle Billiard::calcLinearTrajectory(Particle particle, double alpha) const
 		}
 
 		// True if the the collision happens with the upper wall, false with the lower wall
-		const double xi{(yl > m_r2) ? (m * particle.x + m_r1 - particle.y) / (m + ((m_r1 - m_r2) / m_l))
+		const double xi{isUpperWall ? (m * particle.x + m_r1 - particle.y) / (m + ((m_r1 - m_r2) / m_l))
 									: (m * particle.x - m_r1 - particle.y) / (m + ((m_r2 - m_r1) / m_l))};
 
 		const double yi{m * (xi - particle.x) + particle.y};
@@ -138,14 +140,16 @@ Particle Billiard::calcParabolicTrajectory(Particle particle, double k) const
 
 	while (std::abs(yl) > m_r2)
 	{
+		const bool isUpperWall{yl > m_r2};
+
 		// True if the the collision happens with the upper wall, false with the lower wall
 		const double numerator{
-			(yl > m_r2) ? k + m - std::sqrt((k + m) * (k + m) - 2. * k / m_l * (m * particle.x - particle.y + m_r1))
+			isUpperWall ? k + m - std::sqrt((k + m) * (k + m) - 2. * k / m_l * (m * particle.x - particle.y + m_r1))
 						: k - m - std::sqrt((k - m) * (k - m) + 2. * k / m_l * (m * particle.x - particle.y - m_r1))};
 		const double xi{numerator * m_l / k};
 
 		const double alpha{std::atan(k * (xi - m_l) / m_l)};
-		const double theta{(yl > m_r2) ? updateAngle(particle.theta, alpha) : updateAngle(particle.theta, -alpha)};
+		const double theta{updateAngle(particle.theta, alpha, isUpperWall)};
 
 		if (std::abs(theta) > M_PI_2)
 		{
@@ -175,8 +179,10 @@ Particle Billiard::calcCircularTrajectory(Particle particle, double R) const
 
 	while (std::abs(yl) > m_r2)
 	{
+		const bool isUpperWall{yl > m_r2};
+
 		// True if the the collision happens with the upper wall, false with the lower wall
-		const double k{(yl > m_r2) ? R + m_r2 - particle.y + m * particle.x //
+		const double k{isUpperWall ? R + m_r2 - particle.y + m * particle.x //
 								   : -R - m_r2 - particle.y + m * particle.x};
 		const double a{m * m + 1.};
 		const double b{m_l + m * k};
@@ -185,7 +191,7 @@ Particle Billiard::calcCircularTrajectory(Particle particle, double R) const
 		const double yi{m * (xi - particle.x) + particle.y};
 
 		const double alpha{std::atan((xi - m_l) / (R + m_r2 - yi))};
-		const double theta{(yl > m_r2) ? updateAngle(particle.theta, alpha) : updateAngle(particle.theta, -alpha)};
+		const double theta{updateAngle(particle.theta, alpha, isUpperWall)};
 
 		if (std::abs(theta) > M_PI_2)
 		{
@@ -207,7 +213,8 @@ Particle Billiard::calcCircularTrajectory(Particle particle, double R) const
 }
 } // namespace tb
 
-double tb::Billiard::updateAngle(double theta, double alpha) const
+double tb::Billiard::updateAngle(double theta, double alpha, bool isUpperWall) const
 {
-	return 2. * alpha - theta;
+	return isUpperWall ? 2. * alpha - theta //
+					   : -2. * alpha - theta;
 }

--- a/src/billiard.cpp
+++ b/src/billiard.cpp
@@ -18,6 +18,11 @@ Billiard::Billiard(double r1, double r2, double l, BilliardType type, double e)
 	{
 		throw std::domain_error{"For semicircular billiard, r1 must be greater than r2"};
 	}
+
+	if (m_e < 0 || m_e > 1)
+	{
+		throw std::domain_error{"Coefficient of restitution must be between 0 and 1"};
+	}
 }
 
 std::vector<Particle> Billiard::getEscapedParticles() const

--- a/src/billiard.cpp
+++ b/src/billiard.cpp
@@ -6,7 +6,8 @@
 
 namespace tb
 {
-Billiard::Billiard(double r1, double r2, double l, BilliardType type) : m_r1{r1}, m_r2{r2}, m_l{l}, m_type{type}
+Billiard::Billiard(double r1, double r2, double l, BilliardType type, double e)
+	: m_r1{r1}, m_r2{r2}, m_l{l}, m_type{type}, m_e{e}
 {
 	if (m_r1 <= 0 || m_r2 <= 0 || m_l <= 0)
 	{
@@ -215,6 +216,9 @@ Particle Billiard::calcCircularTrajectory(Particle particle, double R) const
 
 double tb::Billiard::updateAngle(double theta, double alpha, bool isUpperWall) const
 {
-	return isUpperWall ? 2. * alpha - theta //
-					   : -2. * alpha - theta;
+	if (m_e == 1)
+	{
+		return isUpperWall ? 2. * alpha - theta //
+						   : -2. * alpha - theta;
+	}
 }

--- a/src/billiard.cpp
+++ b/src/billiard.cpp
@@ -216,9 +216,12 @@ Particle Billiard::calcCircularTrajectory(Particle particle, double R) const
 
 double tb::Billiard::updateAngle(double theta, double alpha, bool isUpperWall) const
 {
-	if (m_e == 1)
+	if (m_e == 1.)
 	{
 		return isUpperWall ? 2. * alpha - theta //
 						   : -2. * alpha - theta;
 	}
+
+	return isUpperWall ? alpha - M_PI_2 + std::atan(1 / m_e * std::tan(M_PI_2 - theta + alpha)) //
+					   : -alpha + M_PI_2 + std::atan(1 / m_e * std::tan(M_PI_2 - theta - alpha));
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -40,7 +40,11 @@ void setBilliardParams(tb::Billiard& billiard)
 	}
 	const auto billiardType{static_cast<tb::BilliardType>(type)};
 
-	billiard = tb::Billiard{r1, r2, l, billiardType};
+	std::cout << "Insert the coefficient of restitution: ";
+	double e{};
+	getInput(e);
+
+	billiard = tb::Billiard{r1, r2, l, billiardType, e};
 
 	printStars(5);
 	std::cout << "Parameters successfully entered.\n"


### PR DESCRIPTION
This is the last improvement proposed by prof. Giovannozzi.
Adds a parameter, coefficient of restitution $e$, which is the ratio of final and initial component of momentum perpendicular to the billiard after a collision. 
Note that the equation has only been tested with $e=1$, although it should work fine with other values as well.